### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -1,13 +1,16 @@
 version: 2.1
 description: |
   This orb is for NeuVector vulnerability scanning.
+display:
+  home_url: https://neuvector.com/
+  source_url: https://github.com/neuvector/circleci-orb/
 examples:
   image-scan:
     description: Scan a image
     usage:
       version: 2.1
       orbs:
-        neuvector: neuvector/neuvector-orb@1.0.0
+        neuvector: neuvector/neuvector-orb@x.y
       workflows:
         scan-image:
           jobs:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.

Also updated example version in-line with standard practice